### PR TITLE
Updates to the naming of the build script, refresh updated main branch docs

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -3,7 +3,6 @@
 thisDir=${PWD}
 tmpPath="tmp"
 docsPath="docs"
-scriptsPath="scripts"
 gitRepo="https://github.com/hyperledger/aries-cloudagent-python.git"
 
 help() {
@@ -62,10 +61,5 @@ fi
 
 # In the root folder
 cd ${thisDir}
-if [ -e ${scriptsPath}/${gitTag}.sh ]; then
-    echo "Running copy script"
-    ./${scriptsPath}/${gitTag}.sh ${gitTag}
-else
-    ls -al ${scriptsPath}/${gitTag}.sh
-    echo "No copy script for this version: ${scriptsPath}/${gitTag}.sh does not exist"
-fi
+echo "Running copy script"
+./scripts/copyFixMDs.sh ${gitTag}

--- a/docs/contributing/PUBLISHING.md
+++ b/docs/contributing/PUBLISHING.md
@@ -1,0 +1,130 @@
+# How to Publish a New Version
+
+The code to be published should be in the `main` branch. Make sure that all the PRs to go in the release are
+merged, and decide on the release tag. Should it be a release candidate or the final tag, and should it be
+a major, minor or patch release, per [semver](https://semver.org/) rules.
+
+Once ready to do a release, create a local branch that includes the following updates:
+
+1. Create a PR branch from an updated `main` branch.
+
+2. Update the CHANGELOG.md to add the new release.  Only create a new section when working on the first release candidate for a new release. When transitioning from one release candidate to the next, or to an official release, just update the title and date of the change log section.
+
+3. Include details of the merged PRs included in this release. General process to follow:
+
+- Gather the set of PRs since the last release and put them into a list. A good
+  tool to use for this is the
+  [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
+  Steps:
+  - Create a read only GitHub token for your account on this page:
+    [https://github.com/settings/tokens](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token)
+    with a scope of `repo` / `public_repo`.
+  - Use a command like the following, adjusting the tag parameters as
+    appropriate. `docker run -it --rm -v "$(pwd)":/usr/local/src/your-app
+    githubchangeloggenerator/github-changelog-generator --user hyperledger
+    --project aries-cloudagent-python --output 0.7.4-rc0.md --since-tag 0.7.3
+    --future-release 0.7.4-rc0 --release-branch main --token <your-token>`
+  - In the generated file, use only the PR list -- we don't include the list of
+    closed issues in the Change Log.
+
+In some cases, the approach above fails because of too many API calls. An
+alternate approach to getting the list of PRs in the right format is to use this
+scary `sed` pipeline process to get the same output.¥
+
+- Put the following commands into a file called `changelog.sed`
+
+``` bash
+/Approved/d
+/updated /d
+/^$/d
+/^ [0-9]/d
+s/was merged.*//
+/^@/d
+s# by \(.*\) # [\1](https://github.com/\1)#
+s/^ //
+s#  \#\([0-9]*\)# [\#\1](https://github.com/hyperledger/aries-cloudagent-python/pull/\1) #
+s/  / /g
+/^Version/d
+/tasks done/d
+s/^/- /
+```
+
+- Navigate in your browser to the paged list of PRs merged since the last
+  release (using in the GitHub UI a filter such as `is:pr is:merged sort:updated
+  merged:>2022-04-07`) and for each page, highlight, and copy the text
+  of only the list of PRs on the page to use in the following step.
+- For each page, run the command
+  `sed -e :a -e '$!N;s/\n#/ #/;ta' -e 'P;D' <<EOF | sed -f changelog.sed`, 
+  paste in the copied text and then type `EOF`.
+  Redirect the output to a file, appending each page of output to the file.
+  - The first `sed` command in the pipeline merges the PR title and PR number
+    plus author lines onto a single line. The commands in the `changelog.sed`
+    file just clean up the data, removing unwanted lines, etc.
+- At the end of that process, you should have a list of all of the PRs in a form you can
+  use in the CHANGELOG.md file.
+- To verify you have right number of PRs, you can do a `wc` of the file and there
+  should be one line per PR. You should scan the file as well, looking for
+  anomalies, such as missing `\`s before `#` characters. It's a pretty ugly process.
+  - Using a `curl` command and the GitHub API is probably a much better and more
+  robust way to do this, but this was quick and dirty...
+
+Once you have the list of PRs:
+
+- Organize the list into suitable categories, update (if necessary) the PR description and add notes to clarify the changes. See previous release entries to understand the style -- a format should help developers.
+- Add a narrative about the release above the PR that highlights what has gone into the release.
+
+4. Update the ReadTheDocs in the `/docs` folder by following the instructions in
+   the `docs/README.md` file. That will likely add a number of new and modified
+   files to the PR. Eliminate all of the errors in the generation process,
+   either by mocking external dependencies or by fixing ACA-Py code. If
+   necessary, create an issue with the errors and assign it to the appropriate
+   developer. Experience has demonstrated to use that documentation generation
+   errors should be fixed in the code.
+
+5. Update the version number listed in
+   [aries_cloudagent/version.py](https://github.com/hyperledger/aries-cloudagent-python/tree/main/version.py) and, prefixed with
+   a "v" in [open-api/openapi.json](https://github.com/hyperledger/open-api/tree/main/openapi.json) (e.g. "0.7.2" in the
+   version.py file and "v0.7.2" in the openapi.json file). The incremented
+   version number should adhere to the [Semantic Versioning
+   Specification](https://semver.org/#semantic-versioning-specification-semver)
+   based on the changes since the last published release. For Release
+   Candidates, the form of the tag is "0.7.2-rc0".
+  
+6. An extra search of the repo for the existing tag is recommended to see if
+   there are any other instances of the tag in the repo. If any are found to be
+   required (other than in CHANGELOG.md and the examples in this file, of
+   course), finding a way to not need them is best, but if they are needed,
+   please update this document to note where the tag can be found.
+
+7. Double check all of these steps above, and then submit a PR from the branch.
+   Add this new PR to CHANGELOG.md so that all the PRs are included.
+   If there are still further changes to be merged, mark the PR as "Draft",
+   repeat **ALL** of the steps again, and then mark this PR as ready and then
+   wait until it is merged. It's embarrassing when you have to do a whole new
+   release just becaused you missed something silly...I know!
+
+8. Immediately after it is merged, create a new GitHub tag representing the
+   version. The tag name and title of the release should be the same as the
+   version in [aries_cloudagent/version.py](https://github.com/hyperledger/aries-cloudagent-python/tree/main/version.py). Use
+   the "Generate Release Notes" capability to get a sequential listing of the
+   PRs in the release, to complement the manually curated Changelog. Verify on
+   PyPi that the version is published.
+
+9. New images for the release are automatically published by the GitHubAction
+   Workflows: [publish.yml] and [publish-indy.yml]. The actions are triggered
+   when a release is tagged, so no manual action is needed. The images are
+   published in the [Hyperledger Package Repository under
+   aries-cloudagent-python](https://github.com/orgs/hyperledger/packages?repo_name=aries-cloudagent-python)
+   and a link to the packages added to the repositories main page (under
+   "Packages").
+
+   Additional information about the container image publication process can be
+   found in the document [Container Images and Github Actions]().
+
+[publish.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish.yml
+[publish-indy.yml]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/.github/workflows/publish-indy.yml
+[Container Images and Github Actions]: https://github.com/hyperledger/aries-cloudagent-python/blob/main/ContainerImagesAndGithubActions.md
+
+10. Update the ACA-Py Read The Docs site by building the new "latest" (main
+    branch) and activating and building the new release. Appropriate permissions
+    are required to publish the new documentation version.

--- a/docs/features/UsingOpenAPI.md
+++ b/docs/features/UsingOpenAPI.md
@@ -8,7 +8,7 @@ The running agent provides a `Swagger User Interface` that can be browsed and us
 
 ACA-Py uses [aiohttp_apispec](https://github.com/maximdanilchenko/aiohttp-apispec) tags in code to produce the OpenAPI spec file at runtime dependent on what features have been loaded. How these tags are created is documented in the [API Standard Behaviour](https://github.com/hyperledger/aries-cloudagent-python/blob/main/AdminAPI.md#api-standard-behaviour) section of the [Admin API Readme](AdminAPI.md). The OpenAPI spec is available in raw, unformatted form from a running ACA-Py instance using a route of `http://<acapy host and port>/api/docs/swagger.json` or from the browser `Swagger User Interface` directly.
 
-To help identify changes in the ACA-Py Admin API over releases, there is a tool that can be run located at `scripts/generate-open-api-spec`. This tool will start ACA-Py, pull the `swagger.json` file, run a codegen tool, and specify a language output of `json`. Apart from providing a better format to compare changes (i.e., by comparing this output to the checked-in `open-api/openapi.json` version), the tool can be used to identify any non-conformance to the OpenAPI specification. At the moment, `validation` is turned off via the `open-api/openAPIJSON.config` file, so warning messages are printed for non-conformance, but the `json` is still output. Most of the warnings reported by `generate-open-api-spec` relate to missing `operationId` fields which results in manufactured method names being created by codegen tools. At the moment, [aiohttp_apispec](https://github.com/maximdanilchenko/aiohttp-apispec) does not support adding `operationId` annotations via tags.
+The ACA-Py Admin API evolves across releases. To track these changes and ensure conformance with the OpenAPI specification, we provide a tool located at [`scripts/generate-open-api-spec`](scripts/generate-open-api-spec). This tool starts ACA-Py, retrieves the `swagger.json` file, and runs codegen tools to generate specifications in both Swagger and OpenAPI formats with `json` language output. The output of this tool enables comparison with the checked-in `open-api/swagger.json` and `open-api/openapi.json`, and also serves as a useful resource for identifying any non-conformance to the OpenAPI specification. At the moment, `validation` is turned off via the `open-api/openAPIJSON.config` file, so warning messages are printed for non-conformance, but the `json` is still output. Most of the warnings reported by `generate-open-api-spec` relate to missing `operationId` fields which results in manufactured method names being created by codegen tools. At the moment, [aiohttp_apispec](https://github.com/maximdanilchenko/aiohttp-apispec) does not support adding `operationId` annotations via tags.
 
 The `generate-open-api-spec` tool was initially created to help identify issues with method parameters not being sorted, resulting in somewhat random ordering each time a codegen operation was performed. This is relevant for languages which do not have support for [named parameters](https://en.wikipedia.org/wiki/Named_parameter) such as `Javascript`. It is recommended that the `generate-open-api-spec` is run prior to each release, and the resulting `open-api/openapi.json` file checked in to allow tracking of API changes over time. At the moment, this process is not automated as part of the release pipeline.
 
@@ -30,15 +30,15 @@ Another suggestion for code generation is to keep the `modelPropertyNaming` set 
 
 ### Python
 
-- [aries-cloudcontroller (PyPI)](https://pypi.org/project/aries-cloudcontroller/)
-  - [aries-cloudcontroller-python (GitHub)](https://github.com/didx-xyz/aries-cloudcontroller-python)
-- [traction (GitHub)](https://github.com/bcgov/traction/tree/develop/services/traction/acapy_client)
-- [acapy-client (GitHub)](https://github.com/Indicio-tech/acapy-client)
+- [Aries Cloud Controller Python (GitHub / didx-xyz)](https://github.com/didx-xyz/aries-cloudcontroller-python)
+  - [Aries Cloud Controller (PyPi)](https://pypi.org/project/aries-cloudcontroller/)
+- [Traction (GitHub / bcgov)](https://github.com/bcgov/traction)
+- [acapy-client (GitHub / Indicio-tech)](https://github.com/Indicio-tech/acapy-client)
 
 ### Go
 
-- [go-acapy-client (GitHub)](https://github.com/ldej/go-acapy-client)
+- [go-acapy-client (GitHub / Idej)](https://github.com/ldej/go-acapy-client)
 
 ### Java
 
-- [acapy-java-client (GitHub)](https://github.com/hyperledger-labs/acapy-java-client)
+- [ACA-Py Java Client Library (GitHub / hyperledger-labs)](https://github.com/hyperledger-labs/acapy-java-client)

--- a/docs/testing/AgentTracing.md
+++ b/docs/testing/AgentTracing.md
@@ -34,9 +34,9 @@ Environment variables:
 ```
 TRACE_ENABLED          Flag to enable tracing
 
-TRACE_TARGET_URL       Host:port of endpoint to log trace events (e.g. fluentd:8088)
+TRACE_TARGET_URL       Host:port of endpoint to log trace events (e.g. logstash:9700)
 
-DOCKER_NET             Docker network to join (must be used if EFK stack is running in docker)
+DOCKER_NET             Docker network to join (must be used if ELK stack is running in docker)
 
 TRACE_TAG              Tag to be included in all logged trace events
 ```
@@ -83,16 +83,16 @@ Faber      | Connected
 
 When `Exchange Tracing` is `ON`, all exchanges will include tracing.
 
-## Logging Trace Events to an EFK Stack
+## Logging Trace Events to an ELK Stack
 
-You can use the `EFK` stack in the [EFK sub-directory](https://github.com/hyperledger/aries-cloudagent-python/tree/main/demo/EFK-stack) as a target for trace events, just start the EFK stack using the docker-compose file and then in two separate bash shells, startup the demo as follows:
+You can use the `ELK` stack in the [ELK Stack sub-directory](./elk-stack) as a target for trace events, just start the ELK stack using the docker-compose file and then in two separate bash shells, startup the demo as follows:
 
 ```bash
-DOCKER_NET=efk-stack_efk_net TRACE_TARGET_URL=fluentd:8088 ./run_demo faber --trace-http
+DOCKER_NET=elknet TRACE_TARGET_URL=logstash:9700 ./run_demo faber --trace-http
 ```
 
 ```bash
-DOCKER_NET=efk-stack_efk_net TRACE_TARGET_URL=fluentd:8088 ./run_demo alice --trace-http
+DOCKER_NET=elknet TRACE_TARGET_URL=logstash:9700 ./run_demo alice --trace-http
 ```
 
 ## Hooking into event messaging

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,3 +140,4 @@ nav:
     - Maintainers: contributing/MAINTAINERS.md
     - Hyperledger Code of Conduct: contributing/CODE_OF_CONDUCT.md
     - Security Vulnerability Reporting: contributing/SECURITY.md
+    - Publishing an ACA-Py Release: contributing/PUBLISHING.md

--- a/scripts/copyFixMDs.sh
+++ b/scripts/copyFixMDs.sh
@@ -97,6 +97,7 @@ nav:
     - Maintainers: contributing/MAINTAINERS.md
     - Hyperledger Code of Conduct: contributing/CODE_OF_CONDUCT.md
     - Security Vulnerability Reporting: contributing/SECURITY.md
+    - Publishing an ACA-Py Release: contributing/PUBLISHING.md
 EOF
 mv mkdocs.yml.tmp mkdocs.yml  
 
@@ -252,6 +253,9 @@ cp tmp/CONTRIBUTING.md ${FOLDER}
 cp tmp/MAINTAINERS.md ${FOLDER}
 cp tmp/CODE_OF_CONDUCT.md ${FOLDER}
 cp tmp/SECURITY.md ${FOLDER}
+FILE=PUBLISHING.md; sed -e "s#(aries_cloudagent/#(https://github.com/hyperledger/aries-cloudagent-python/tree/${VERSION}/#" \
+  -e "s#(open-api/#(https://github.com/hyperledger/open-api/tree/${VERSION}/#" \
+  tmp/${FILE} > ${FOLDER}/${FILE}; diff tmp/${FILE} ${FOLDER}/${FILE}
 
 # Update all references to "main" to "${VERSION}" in Github pathes
 # Naively for now:

--- a/scripts/diffMDs.sh
+++ b/scripts/diffMDs.sh
@@ -14,4 +14,9 @@ files1=$(find "$dir1" -name "*.md" -type f -exec basename {} \;)
 files2=$(find "$dir2" -name "*.md" -type f -exec basename {} \;)
 
 # Diff the basenames of the files
+echo Added documents are only in the generated site set of documents.
+echo "acapy-README.md" is a copy of the ACA-Py README.md to the generated site, so is OK to be listed here.
+echo Deleted documents are only in the ACA-Py repo.
+echo This script isn\'t great with the various README.md files in ACA-Py, so new ones might be missed.
+echo ""
 diff <(echo "$files1" | sort -u) <(echo "$files2" | sort -u)


### PR DESCRIPTION
Instead of having the script named by the ACA-Py release tag, just use the same name. It's tag in this repo is sufficient to know that.

Also tweaked the "diffMDs.sh" script that detects if there are MD files in ACA-Py that aren't in the documentation site.

Updated the MDs that have changed in ACA-Py since the last published release, and added the "Publishing" document to the generated site, because...why not?
